### PR TITLE
🧹 Refactor duplicated sub-header styling

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,7 +80,7 @@ if full_data is not None and closes is not None:
 
     # --- TAB 1: MARKETS ---
     with tab1:
-        st.markdown('<div class="steel-sub-header"><span class="steel-text-main" style="font-size: 20px !important;">Global Asset Grid</span></div>', unsafe_allow_html=True)
+        st.markdown(styles.render_sub_header("Global Asset Grid"), unsafe_allow_html=True)
         assets = [
             {"name": "Dow Jones", "ticker": "^DJI", "color": "#00CC00"},
             {"name": "S&P 500", "ticker": "SPY", "color": "#00CC00"},
@@ -103,7 +103,7 @@ if full_data is not None and closes is not None:
         st.divider()
         
         # Deep Dive Chart
-        st.markdown('<div class="steel-sub-header"><span class="steel-text-main" style="font-size: 20px !important;">Swarm Deep Dive</span></div>', unsafe_allow_html=True)
+        st.markdown(styles.render_sub_header("Swarm Deep Dive"), unsafe_allow_html=True)
         if 'SPY' in closes:
             spy = closes['SPY']
             # FIXED: logic.calc_ppo
@@ -150,7 +150,7 @@ if full_data is not None and closes is not None:
 
     # --- TAB 2: SAFETY ---
     with tab2:
-        st.markdown('<div class="steel-sub-header"><span class="steel-text-main" style="font-size: 20px !important;">Safety Level</span></div>', unsafe_allow_html=True)
+        st.markdown(styles.render_sub_header("Safety Level"), unsafe_allow_html=True)
         col1, col2 = st.columns([2, 1])
         with col1:
             st.markdown(f'<div class="gov-pill" style="background: linear-gradient(135deg, {color}, {color}88); border: 1px solid {color};">{status}</div>', unsafe_allow_html=True)
@@ -171,7 +171,7 @@ if full_data is not None and closes is not None:
 
     # --- TAB 3: STRATEGIST ---
     with tab3:
-        st.markdown('<div class="steel-sub-header"><span class="steel-text-main" style="font-size: 20px !important;">MacroEffects: Chief Strategist\'s View</span></div>', unsafe_allow_html=True)
+        st.markdown(styles.render_sub_header("MacroEffects: Chief Strategist's View"), unsafe_allow_html=True)
         try:
             update_df = logic.get_strategist_update()
             if update_df is not None:

--- a/styles.py
+++ b/styles.py
@@ -100,13 +100,13 @@ def apply_theme():
     [data-testid="stPopover"] button {{
         border: 1px solid #333333;
         background: #000000;
-        color: #C6A87C; 
+        color: #C6A87C;
         font-size: 28px !important;
         font-weight: bold;
-        height: 70px; 
+        height: 70px;
         width: 100%;
         margin-top: 0px;
-        border-radius: 0 8px 8px 0; 
+        border-radius: 0 8px 8px 0;
         border-left: 1px solid #333333;
         box-shadow: 0 4px 6px rgba(0,0,0,0.5);
         display: flex;
@@ -182,7 +182,7 @@ def apply_theme():
     .market-ticker {{ color: var(--text-secondary); font-size: 11px; margin-bottom: 2px; }}
     .market-price {{ color: var(--text-primary); font-family: 'Fira Code', monospace; font-size: 22px; font-weight: 700; margin: 2px 0; }}
     .market-delta {{ font-family: 'Fira Code', monospace; font-size: 13px; font-weight: 600; }}
-    
+
     div[data-testid="stMetricLabel"] {{ color: var(--text-secondary) !important; font-size: 14px !important; font-weight: 500 !important; }}
     div[data-testid="stMetricValue"] {{ color: var(--text-primary) !important; }}
     header[data-testid="stHeader"] {{ visibility: hidden; }}
@@ -191,7 +191,7 @@ def apply_theme():
     div[data-testid="stHorizontalBlock"] {{ gap: 0rem !important; }}
     </style>
     """, unsafe_allow_html=True)
-    
+
     return theme
 
 def render_market_card(name, price, delta, pct):
@@ -214,6 +214,9 @@ def render_sparkline(data, line_color):
     fig.add_trace(go.Scatter(x=data.index, y=data, mode='lines', line=dict(color=line_color, width=2), hoverinfo='skip'))
     fig.update_layout(height=40, margin=dict(l=0,r=0,t=0,b=0), xaxis=dict(visible=False), yaxis=dict(visible=False), plot_bgcolor='rgba(0,0,0,0)', paper_bgcolor='rgba(0,0,0,0)')
     return fig
+
+def render_sub_header(text):
+    return f'<div class="steel-sub-header"><span class="steel-text-main" style="font-size: 20px !important;">{text}</span></div>'
 
 FOOTER_HTML = """
 <div style="font-family: 'Fira Code', monospace; font-size: 10px; color: #888; text-align: center; margin-top: 50px; border-top: 1px solid #30363d; padding-top: 20px; text-transform: uppercase;">

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -1,0 +1,22 @@
+import unittest
+import sys
+import os
+
+# Add parent directory to path so we can import styles
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import styles
+
+class TestStyles(unittest.TestCase):
+    def test_render_sub_header(self):
+        text = "Test Header"
+        expected = '<div class="steel-sub-header"><span class="steel-text-main" style="font-size: 20px !important;">Test Header</span></div>'
+        # Check if the function exists first (for TDD, it won't yet)
+        if hasattr(styles, 'render_sub_header'):
+            result = styles.render_sub_header(text)
+            self.assertEqual(result, expected)
+        else:
+            self.fail("render_sub_header not implemented in styles.py")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
  - Refactored 4 occurrences of duplicated raw HTML sub-header styling in `app.py`.
  - Created a helper function `render_sub_header(text)` in `styles.py`.
  - Added a regression test `tests/test_styles.py`.

💡 **Why:** How this improves maintainability
  - Reduces code duplication.
  - Centralizes styling logic for sub-headers, making future design changes easier (single source of truth).
  - Improves readability of `app.py`.

✅ **Verification:** How you confirmed the change is safe
  - Created and ran `tests/test_styles.py` to verify the helper function output.
  - Ran syntax checks on `app.py` and `styles.py`.
  - Verified visually using a Playwright script and screenshots that the UI remains identical.
  - Checked `app.py` to ensure all occurrences were replaced correctly.

✨ **Result:** The improvement achieved
  - Cleaner codebase with reusable styling logic.
  - No visual regression.

---
*PR created automatically by Jules for task [5068348188074254800](https://jules.google.com/task/5068348188074254800) started by @andytweeterman*