### PR TITLE
Refactor redundant PPO calculation in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,6 +76,11 @@ st.divider()
 # 6. MAIN CONTENT GRID
 if full_data is not None and closes is not None:
     
+    # Pre-calculate SPY PPO for use across tabs
+    spy_ppo, spy_sig, spy_hist = None, None, None
+    if 'SPY' in closes:
+        spy_ppo, spy_sig, spy_hist = logic.calc_ppo(closes['SPY'])
+
     tab1, tab2, tab3 = st.tabs(["Markets", "Safety & Stress Tests", "Strategist"])
 
     # --- TAB 1: MARKETS ---
@@ -107,7 +112,7 @@ if full_data is not None and closes is not None:
         if 'SPY' in closes:
             spy = closes['SPY']
             # FIXED: logic.calc_ppo
-            ppo, sig, hist = logic.calc_ppo(spy)
+            ppo, sig, hist = spy_ppo, spy_sig, spy_hist
             # FIXED: logic.calc_cone
             sma, std, u_cone, l_cone = logic.calc_cone(spy)
             # FIXED: logic.generate_forecast
@@ -162,8 +167,8 @@ if full_data is not None and closes is not None:
         st.subheader("⏱️ Tactical Horizons")
         if 'SPY' in closes:
             # FIXED: logic.calc_ppo
-            latest_hist = logic.calc_ppo(closes['SPY'])[2].iloc[-1]
-            latest_ppo = logic.calc_ppo(closes['SPY'])[0].iloc[-1]
+            latest_hist = spy_hist.iloc[-1]
+            latest_ppo = spy_ppo.iloc[-1]
             h1, h2, h3 = st.columns(3)
             with h1: st.info("**1 WEEK (Momentum)**"); st.markdown("🟢 **RISING**" if latest_hist > 0 else "🔴 **WEAKENING**")
             with h2: st.info("**1 MONTH (Trend)**"); st.markdown("🟢 **BULLISH**" if latest_ppo > 0 else "🔴 **BEARISH**")

--- a/tests/test_logic.py
+++ b/tests/test_logic.py
@@ -1,0 +1,51 @@
+import unittest
+import pandas as pd
+import numpy as np
+import sys
+import os
+
+# Add the parent directory to sys.path to import logic
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+import logic
+
+class TestLogic(unittest.TestCase):
+    def test_calc_ppo_with_series(self):
+        # Create a sample series with enough data points for PPO
+        # PPO uses EMA 12 and 26, so we need at least 26 points to get non-NaN results?
+        # Actually EMA uses adjust=False, so it starts calculating from the beginning with the first value.
+
+        # Generate some dummy price data
+        dates = pd.date_range(start='2023-01-01', periods=50)
+        prices = pd.Series(np.linspace(100, 150, 50), index=dates)
+
+        ppo, sig, hist = logic.calc_ppo(prices)
+
+        # Check types
+        self.assertIsInstance(ppo, pd.Series)
+        self.assertIsInstance(sig, pd.Series)
+        self.assertIsInstance(hist, pd.Series)
+
+        # Check lengths
+        self.assertEqual(len(ppo), 50)
+        self.assertEqual(len(sig), 50)
+        self.assertEqual(len(hist), 50)
+
+        # Check values are not all NaN (adjust=False means no initial NaNs usually, except maybe first few)
+        # Actually pandas ewm with adjust=False starts immediately.
+        self.assertFalse(ppo.isnull().all())
+        self.assertFalse(sig.isnull().all())
+        self.assertFalse(hist.isnull().all())
+
+    def test_calc_ppo_with_dataframe(self):
+        # Test the logic that handles DataFrame input
+        dates = pd.date_range(start='2023-01-01', periods=50)
+        df = pd.DataFrame({'Close': np.linspace(100, 150, 50)}, index=dates)
+
+        ppo, sig, hist = logic.calc_ppo(df)
+
+        self.assertIsInstance(ppo, pd.Series)
+        self.assertEqual(len(ppo), 50)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Refactor app.py to calculate SPY PPO once in the main data processing block and reuse the result in Tab 1 and Tab 2, eliminating redundant calculations. Also added tests/test_logic.py to verify logic.calc_ppo functionality.

---
*PR created automatically by Jules for task [17132547280860815938](https://jules.google.com/task/17132547280860815938) started by @andytweeterman*