### PR TITLE
🔒 Fix Stored XSS / Content Injection in Strategist View

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import html
 import pandas as pd
 import plotly.graph_objects as go
 from plotly.subplots import make_subplots
@@ -177,8 +178,11 @@ if full_data is not None and closes is not None:
             if update_df is not None:
                 update_data = dict(zip(update_df['Key'], update_df['Value']))
                 with st.expander(f"Read Forecast ({update_data.get('Date', 'Current')})", expanded=True):
-                    st.markdown(f'**"{update_data.get("Title", "Market Update")}"**')
-                    st.markdown(str(update_data.get('Text', '')).replace("\\n", "\n"))
+                    title = html.escape(update_data.get("Title", "Market Update"))
+                    st.markdown(f'<div style="font-weight:bold">"{title}"</div>', unsafe_allow_html=True)
+                    text = str(update_data.get('Text', '')).replace("\\n", "\n")
+                    safe_text = html.escape(text).replace("\n", "<br>")
+                    st.markdown(f'<div>{safe_text}</div>', unsafe_allow_html=True)
                 st.info("💡 **Analyst Note:** This commentary is pulled live from the Chief Strategist's desk via the Alpha Swarm CMS.")
             else: st.warning("Strategist feed temporarily unavailable.")
         except Exception: st.warning("Strategist feed temporarily unavailable.")


### PR DESCRIPTION
This PR fixes a stored XSS / Content Injection vulnerability in the "Strategist" tab of `app.py`. The previous implementation used `st.markdown` on untrusted input, which allowed malicious actors to inject Markdown (links, images) or potentially HTML/JS if the environment allowed.

**Changes:**
- Imported `html` module.
- Modified the rendering of the Strategist update title and text.
- Escaped all HTML special characters in the input.
- Wrapped the content in `<div>` tags (block-level elements) which prevents Streamlit's Markdown parser from interpreting the content as Markdown.
- Manually handled newlines by replacing `\n` with `<br>`.
- Applied bold styling to the title using inline CSS on the `<div>`.

**Verification:**
- Validated using a reproduction script (`reproduce_issue.py`) with malicious payloads including Markdown links, images, and script tags.
- Confirmed that the fix renders the payloads as plain text.
- Verified that the main application (`app.py`) loads correctly and displays the Strategist tab as intended.


---
*PR created automatically by Jules for task [9657592203390582083](https://jules.google.com/task/9657592203390582083) started by @andytweeterman*