### PR TITLE
⚡ Replace .apply() with np.select() for column transformation in mock_data.py

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,58 @@
+import timeit
+import pandas as pd
+import numpy as np
+
+def setup_data(n=10000):
+    df = pd.DataFrame({'diff': np.random.uniform(-20, 20, n)})
+    return df
+
+def original_apply(df):
+    def get_trend(change):
+        if change > 15:
+            return 'DoubleUp'
+        elif 10 < change <= 15:
+            return 'SingleUp'
+        elif 5 < change <= 10:
+            return 'FortyFiveUp'
+        elif -5 <= change <= 5:
+            return 'Flat'
+        elif -10 <= change < -5:
+            return 'FortyFiveDown'
+        elif -15 <= change < -10:
+            return 'SingleDown'
+        else: # change < -15
+            return 'DoubleDown'
+    return df['diff'].apply(get_trend)
+
+def optimized_select(df):
+    conditions = [
+        df['diff'] > 15,
+        (df['diff'] > 10) & (df['diff'] <= 15),
+        (df['diff'] > 5) & (df['diff'] <= 10),
+        (df['diff'] >= -5) & (df['diff'] <= 5),
+        (df['diff'] >= -10) & (df['diff'] < -5),
+        (df['diff'] >= -15) & (df['diff'] < -10)
+    ]
+    choices = [
+        'DoubleUp',
+        'SingleUp',
+        'FortyFiveUp',
+        'Flat',
+        'FortyFiveDown',
+        'SingleDown'
+    ]
+    return np.select(conditions, choices, default='DoubleDown')
+
+if __name__ == '__main__':
+    df = setup_data(100000)
+
+    # check correctness
+    assert (original_apply(df) == optimized_select(df)).all()
+
+    n_iter = 100
+    t1 = timeit.timeit(lambda: original_apply(df), number=n_iter)
+    t2 = timeit.timeit(lambda: optimized_select(df), number=n_iter)
+
+    print(f"Original apply: {t1:.4f} seconds")
+    print(f"Optimized select: {t2:.4f} seconds")
+    print(f"Speedup: {t1/t2:.2f}x")

--- a/mock_data.py
+++ b/mock_data.py
@@ -61,23 +61,23 @@ def get_mock_cgm():
     # Calculate difference
     df['diff'] = df['Glucose_Value'].diff().fillna(0)
 
-    def get_trend(change):
-        if change > 15:
-            return 'DoubleUp'
-        elif 10 < change <= 15:
-            return 'SingleUp'
-        elif 5 < change <= 10:
-            return 'FortyFiveUp'
-        elif -5 <= change <= 5:
-            return 'Flat'
-        elif -10 <= change < -5:
-            return 'FortyFiveDown'
-        elif -15 <= change < -10:
-            return 'SingleDown'
-        else: # change < -15
-            return 'DoubleDown'
-
-    df['Trend'] = df['diff'].apply(get_trend)
+    conditions = [
+        df['diff'] > 15,
+        (df['diff'] > 10) & (df['diff'] <= 15),
+        (df['diff'] > 5) & (df['diff'] <= 10),
+        (df['diff'] >= -5) & (df['diff'] <= 5),
+        (df['diff'] >= -10) & (df['diff'] < -5),
+        (df['diff'] >= -15) & (df['diff'] < -10)
+    ]
+    choices = [
+        'DoubleUp',
+        'SingleUp',
+        'FortyFiveUp',
+        'Flat',
+        'FortyFiveDown',
+        'SingleDown'
+    ]
+    df['Trend'] = np.select(conditions, choices, default='DoubleDown')
 
     # Drop the diff column as it's not requested in the final output
     df = df.drop(columns=['diff'])


### PR DESCRIPTION
💡 **What:** 
Replaced the pandas `.apply(get_trend)` operation with a vectorized numpy operation utilizing `np.select()`.

🎯 **Why:** 
`.apply()` iterates through each row sequentially, which has significant overhead and doesn't take advantage of C-level vectorization inside pandas and numpy. Replacing it with `np.select()` leverages vectorized C loops to apply conditions in bulk, substantially speeding up the transformation.

📊 **Measured Improvement:** 
Before the change, a local benchmark processing 100,000 generated entries 100 times showed:
- Original `apply`: ~5.25 seconds
- Optimized `select`: ~0.60 seconds
This demonstrates an 8.80x speedup for this specific column operation.

---
*PR created automatically by Jules for task [5918466411010567108](https://jules.google.com/task/5918466411010567108) started by @andytweeterman*